### PR TITLE
mp4pfile: add missing stdint.h

### DIFF
--- a/src/mp4pfile.c
+++ b/src/mp4pfile.c
@@ -7,6 +7,7 @@
 //
 
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <mp4p/mp4pfile.h>


### PR DESCRIPTION
Provides `int64_t`. This change is needed to compile successfully in msys2 environment.